### PR TITLE
Add state parameter to authorize_url

### DIFF
--- a/lib/omniauth-linkedin-oauth2/version.rb
+++ b/lib/omniauth-linkedin-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LinkedInOAuth2
-    VERSION = "0.1.1.1"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -9,14 +9,14 @@ module OmniAuth
 
       # This is where you pass the options you would pass when
       # initializing your consumer from the OAuth gem.
+      state = SecureRandom.hex
       
       option :client_options, {
         :site => 'https://api.linkedin.com',
-        :authorize_url => 'https://www.linkedin.com/uas/oauth2/authorization?response_type=code',
+        :authorize_url => 'https://www.linkedin.com/uas/oauth2/authorization?response_type=code&state=' + state,
         :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken'
       }
 
-      option :state, SecureRandom.hex
       option :scope, 'r_basicprofile r_emailaddress'
       option :fields, ['id', 'email-address', 'first-name', 'last-name', 'headline', 'location', 'industry', 'picture-url', 'public-profile-url']
 


### PR DESCRIPTION
Hi and thank you for this great gem,

I tried to use your gem in a project to perfom a linkedin connect but it always redirects me to linkedin.com with an Invalid Request error when I perform a GET of /auth/linkedin.
So, I looked into your gem to see what was done and I found out that in the API documentation (https://developer.linkedin.com/documents/authentication) there is a parameter called state that is required to the authentication process and that is not passed by the gem.
This parameter is required because it's used to prevent CSRF.
So, I just added to the gem this parameter in the autorize_url with a random string as a value and it works fine now.

I think that it's worth adding to your current version because it's simply not working without that.
