### PR TITLE
Fixes issue with query params vs. post body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-gemset
+.ruby-version

--- a/lib/omniauth-linkedin-oauth2/version.rb
+++ b/lib/omniauth-linkedin-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LinkedInOAuth2
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -14,6 +14,10 @@ module OmniAuth
         :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken'
       }
 
+      option :token_params, {
+        :mode => :query
+      }
+
       option :scope, 'r_basicprofile r_emailaddress'
       option :fields, ['id', 'email-address', 'first-name', 'last-name', 'headline', 'location', 'industry', 'picture-url', 'public-profile-url']
 

--- a/spec/omniauth/strategies/linkedin_oauth2_spec.rb
+++ b/spec/omniauth/strategies/linkedin_oauth2_spec.rb
@@ -20,6 +20,10 @@ describe OmniAuth::Strategies::LinkedIn do
     it 'has correct token url' do
       subject.client.options[:token_url].should eq('https://www.linkedin.com/uas/oauth2/accessToken')
     end
+
+    it 'posts params using the :query mode' do
+      subject.options.token_params[:mode].should == :query
+    end
   end
 
   describe '#callback_path' do


### PR DESCRIPTION
There's been a recent problem with LinkedIn authorizations, and this workaround should fix the problem. See:
http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token#comment-28937
