### PR TITLE
update :token_method option to use GET (temporary workaround)

### DIFF
--- a/lib/omniauth-linkedin-oauth2/version.rb
+++ b/lib/omniauth-linkedin-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LinkedInOAuth2
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -11,7 +11,8 @@ module OmniAuth
       option :client_options, {
         :site => 'https://api.linkedin.com',
         :authorize_url => 'https://www.linkedin.com/uas/oauth2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken'
+        :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken',
+        :token_method => :get
       }
 
       option :token_params, {

--- a/spec/omniauth/strategies/linkedin_oauth2_spec.rb
+++ b/spec/omniauth/strategies/linkedin_oauth2_spec.rb
@@ -21,6 +21,10 @@ describe OmniAuth::Strategies::LinkedIn do
       subject.client.options[:token_url].should eq('https://www.linkedin.com/uas/oauth2/accessToken')
     end
 
+    it 'has correct token url' do
+      subject.client.options[:token_method].should eq(:get)
+    end
+
     it 'posts params using the :query mode' do
       subject.options.token_params[:mode].should == :query
     end


### PR DESCRIPTION
LinkedIn is having problems interpreting POST requests with parameters in the POST body. This workaround gets around the problem by using the GET method to request Access Tokens until LinkedIn can fix the problem. See: http://developer.linkedin.com/comment/29010#comment-29010
