### PR TITLE
Reverting back to the original accessToken POST now that LinkedIn is fixed

### DIFF
--- a/lib/omniauth-linkedin-oauth2/version.rb
+++ b/lib/omniauth-linkedin-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LinkedInOAuth2
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -11,12 +11,7 @@ module OmniAuth
       option :client_options, {
         :site => 'https://api.linkedin.com',
         :authorize_url => 'https://www.linkedin.com/uas/oauth2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken',
-        :token_method => :get
-      }
-
-      option :token_params, {
-        :mode => :query
+        :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken'
       }
 
       option :scope, 'r_basicprofile r_emailaddress'

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -20,14 +20,6 @@ describe OmniAuth::Strategies::LinkedIn do
     it 'has correct token url' do
       subject.client.options[:token_url].should eq('https://www.linkedin.com/uas/oauth2/accessToken')
     end
-
-    it 'has correct token url' do
-      subject.client.options[:token_method].should eq(:get)
-    end
-
-    it 'posts params using the :query mode' do
-      subject.options.token_params[:mode].should == :query
-    end
   end
 
   describe '#callback_path' do


### PR DESCRIPTION
LinkedIn has fixed the issue with the accessToken POST request, so we can revert back to the original OAuth2 compliant implementation.

https://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token?page=1#comment-29010
