### PR TITLE
Add support for returning secure avatar when secure_image_url is set.

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -56,7 +56,9 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get("/v1/people/~:(#{options.fields.join(',')})?format=json").parsed
+        fields = options.fields
+        fields.map! { |f| f == "picture-url" ? "picture-url;secure=true" : f } if !!options[:secure_image_url]
+        @raw_info ||= access_token.get("/v1/people/~:(#{fields.join(',')})?format=json").parsed
       end
 
       private


### PR DESCRIPTION
Similar to [omniauth-twitter](https://github.com/arunagw/omniauth-twitter) and [omniauth-facebook](https://github.com/mkdynamic/omniauth-facebook), when `secure_image_url` is set, the secure avatar URL is returned for `picture-url` field.
