### PR TITLE
Update RSpec to ~> 2.14.1 and convert specs to new syntax

### DIFF
--- a/omniauth-linkedin-oauth2.gemspec
+++ b/omniauth-linkedin-oauth2.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake'
 
-  gem.add_development_dependency 'rspec', '~> 2.13.0'
+  gem.add_development_dependency 'rspec', '~> 2.14.1'
   gem.add_development_dependency 'simplecov'
 end

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -5,86 +5,86 @@ describe OmniAuth::Strategies::LinkedIn do
   subject { OmniAuth::Strategies::LinkedIn.new(nil) }
 
   it 'should add a camelization for itself' do
-    OmniAuth::Utils.camelize('linkedin').should == 'LinkedIn'
+    expect(OmniAuth::Utils.camelize('linkedin')).to eq('LinkedIn')
   end
 
   describe '#client' do
     it 'has correct LinkedIn site' do
-      subject.client.site.should eq('https://api.linkedin.com')
+      expect(subject.client.site).to eq('https://api.linkedin.com')
     end
 
     it 'has correct authorize url' do
-      subject.client.options[:authorize_url].should eq('https://www.linkedin.com/uas/oauth2/authorization?response_type=code')
+      expect(subject.client.options[:authorize_url]).to eq('https://www.linkedin.com/uas/oauth2/authorization?response_type=code')
     end
 
     it 'has correct token url' do
-      subject.client.options[:token_url].should eq('https://www.linkedin.com/uas/oauth2/accessToken')
+      expect(subject.client.options[:token_url]).to eq('https://www.linkedin.com/uas/oauth2/accessToken')
     end
   end
 
   describe '#callback_path' do
     it 'has the correct callback path' do
-      subject.callback_path.should eq('/auth/linkedin/callback')
+      expect(subject.callback_path).to eq('/auth/linkedin/callback')
     end
   end
 
   describe '#uid' do
     before :each do
-      subject.stub(:raw_info) { { 'id' => 'uid' } }
+      allow(subject).to receive(:raw_info) { { 'id' => 'uid' } }
     end
 
     it 'returns the id from raw_info' do
-      subject.uid.should eq('uid')
+      expect(subject.uid).to eq('uid')
     end
   end
 
   describe '#info' do
     before :each do
-      subject.stub(:raw_info) { {} }
+      allow(subject).to receive(:raw_info) { {} }
     end
 
     context 'and therefore has all the necessary fields' do
-      it { subject.info.should have_key :name }
-      it { subject.info.should have_key :email }
-      it { subject.info.should have_key :nickname }
-      it { subject.info.should have_key :first_name }
-      it { subject.info.should have_key :last_name }
-      it { subject.info.should have_key :location }
-      it { subject.info.should have_key :description }
-      it { subject.info.should have_key :image }
-      it { subject.info.should have_key :urls }
+      it { expect(subject.info).to have_key :name }
+      it { expect(subject.info).to have_key :email }
+      it { expect(subject.info).to have_key :nickname }
+      it { expect(subject.info).to have_key :first_name }
+      it { expect(subject.info).to have_key :last_name }
+      it { expect(subject.info).to have_key :location }
+      it { expect(subject.info).to have_key :description }
+      it { expect(subject.info).to have_key :image }
+      it { expect(subject.info).to have_key :urls }
     end
   end
 
   describe '#extra' do
     before :each do
-      subject.stub(:raw_info) { { :foo => 'bar' } }
+      allow(subject).to receive(:raw_info) { { :foo => 'bar' } }
     end
 
-    it { subject.extra['raw_info'].should eq({ :foo => 'bar' }) }
+    it { expect(subject.extra['raw_info']).to eq({ :foo => 'bar' }) }
   end
 
   describe '#access_token' do
     before :each do
-      subject.stub(:oauth2_access_token) { double('oauth2 access token', :expires_in => 3600, :expires_at => 946688400).as_null_object }
+      allow(subject).to receive(:oauth2_access_token) { double('oauth2 access token', :expires_in => 3600, :expires_at => 946688400).as_null_object }
     end
 
-    it { subject.access_token.expires_in.should eq(3600) }
-    it { subject.access_token.expires_at.should eq(946688400) }
+    it { expect(subject.access_token.expires_in).to eq(3600) }
+    it { expect(subject.access_token.expires_at).to eq(946688400) }
   end
 
   describe '#raw_info' do
     before :each do
       access_token = double('access token')
       response = double('response', :parsed => { :foo => 'bar' })
-      access_token.should_receive(:get).with("/v1/people/~:(baz,qux)?format=json").and_return(response)
+      expect(access_token).to receive(:get).with("/v1/people/~:(baz,qux)?format=json").and_return(response)
 
-      subject.stub(:option_fields) { ['baz', 'qux'] }
-      subject.stub(:access_token) { access_token }
+      allow(subject).to receive(:option_fields) { ['baz', 'qux'] }
+      allow(subject).to receive(:access_token) { access_token }
     end
 
     it 'returns parsed response from access token' do
-      subject.raw_info.should eq({ :foo => 'bar' })
+      expect(subject.raw_info).to eq({ :foo => 'bar' })
     end
   end
 
@@ -95,7 +95,7 @@ describe OmniAuth::Strategies::LinkedIn do
       end
 
       it 'sets default scope' do
-        subject.authorize_params['scope'].should eq('r_basicprofile r_emailaddress')
+        expect(subject.authorize_params['scope']).to eq('r_basicprofile r_emailaddress')
       end
     end
   end
@@ -103,19 +103,19 @@ describe OmniAuth::Strategies::LinkedIn do
   describe '#option_fields' do
     it 'returns options fields' do
       subject.stub(:options => double('options', :fields => ['foo', 'bar']).as_null_object)
-      subject.send(:option_fields).should eq(['foo', 'bar'])
+      expect(subject.send(:option_fields)).to eq(['foo', 'bar'])
     end
 
     it 'http avatar image by default' do
       subject.stub(:options => double('options', :fields => ['picture-url']))
-      subject.options.stub(:[]).with(:secure_image_url).and_return(false)
-      subject.send(:option_fields).should eq(['picture-url'])
+      allow(subject.options).to receive(:[]).with(:secure_image_url).and_return(false)
+      expect(subject.send(:option_fields)).to eq(['picture-url'])
     end
 
     it 'https avatar image if secure_image_url truthy' do
       subject.stub(:options => double('options', :fields => ['picture-url']))
-      subject.options.stub(:[]).with(:secure_image_url).and_return(true)
-      subject.send(:option_fields).should eq(['picture-url;secure=true'])
+      allow(subject.options).to receive(:[]).with(:secure_image_url).and_return(true)
+      expect(subject.send(:option_fields)).to eq(['picture-url;secure=true'])
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 23 conversions
  from: obj.should
    to: expect(obj).to
- 8 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 1 conversion
  from: == expected
    to: eq(expected)
- 1 conversion
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
