### PR TITLE
Added callback_url option

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -59,6 +59,10 @@ module OmniAuth
         @raw_info ||= access_token.get("/v1/people/~:(#{option_fields.join(',')})?format=json").parsed
       end
 
+      def callback_url
+        options[:callback_url] || super
+      end
+
       private
 
       def option_fields


### PR DESCRIPTION
Added the OmniAuth callback_url option to specify a specific URL.
In my use case I needed to specify a different callback url and different schema (https instead of http).

Also resolves issue #26 