### PR TITLE
Overrode omniauth-oauth2 callback to exclude params

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -44,6 +44,10 @@ module OmniAuth
         { 'raw_info' => raw_info }
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       alias :oauth2_access_token :access_token
 
       def access_token


### PR DESCRIPTION
Before omniauth-oauth2 version 1.4, the oauth2 strategy overrode the callback_url method to exclude querystring parameters. However, in version 1.4 (see https://github.com/intridea/omniauth-oauth2/pull/70) override was removed, which means that querystring parameters are now included (by omniauth-linkedin-oauth2 and every other omniauth-oauth2 gem). Unfortunately, LinkedIn expects a callback without any querystring parameters, and if you use this gem with omniauth-oauth2 version 1.4+ you will get this error:

```
I, [2015-10-29T17:36:27.934054 #49096]  INFO -- omniauth: (linkedin) Callback phase initiated.
"callback_url: http://localhost:3000/users/auth/linkedin/callback?code=UlArqHqkcV0iHYoJENjq088IlbEcYnYbeXVHu7LzpGi2u5gYDmYHXk8xajWeM1ryKESL41ng3VyIAerJV3Ac3CF4hj4616mmkLWluXNQKXR7Qr0iiQ8&state=940cff5c6d64870a5bc7db6158b534e994860c8f55a55a0e"
E, [2015-10-29T17:36:28.754548 #49096] ERROR -- omniauth: (linkedin) Authentication failure! invalid_credentials: OAuth2::Error, invalid_request: missing required parameters, includes an invalid parameter value, parameter more than once. : Unable to retrieve access token : appId or redirect uri does not match authorization code or authorization code expired
{"error_description":"missing required parameters, includes an invalid parameter value, parameter more than once. : Unable to retrieve access token : appId or redirect uri does not match authorization code or authorization code expired","error":"invalid_request”}
```

To fix that, I've pulled the override that used to be in omniauth-oauth2 down into omniauth-linkedin-oauth2, so it maintains the same behaviour regardless of which version of omniauth-oauth2 is being used.