### PR TITLE
Use new authorization_url and token_url

### DIFF
--- a/lib/omniauth-linkedin-oauth2/version.rb
+++ b/lib/omniauth-linkedin-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LinkedInOAuth2
-    VERSION = "0.1.5"
+    VERSION = "0.2.5"
   end
 end

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -10,8 +10,8 @@ module OmniAuth
       # initializing your consumer from the OAuth gem.
       option :client_options, {
         :site => 'https://api.linkedin.com',
-        :authorize_url => 'https://www.linkedin.com/uas/oauth2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/uas/oauth2/accessToken'
+        :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
+        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
       }
 
       option :scope, 'r_basicprofile r_emailaddress'

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -14,11 +14,11 @@ describe OmniAuth::Strategies::LinkedIn do
     end
 
     it 'has correct authorize url' do
-      expect(subject.client.options[:authorize_url]).to eq('https://www.linkedin.com/uas/oauth2/authorization?response_type=code')
+      expect(subject.client.options[:authorize_url]).to eq('https://www.linkedin.com/oauth/v2/authorization?response_type=code')
     end
 
     it 'has correct token url' do
-      expect(subject.client.options[:token_url]).to eq('https://www.linkedin.com/uas/oauth2/accessToken')
+      expect(subject.client.options[:token_url]).to eq('https://www.linkedin.com/oauth/v2/accessToken')
     end
   end
 


### PR DESCRIPTION
According to [LinkedIn documentation](https://developer.linkedin.com/docs/oauth2)
and [the document of legacy authentication](https://developer.linkedin.com/docs/oauth2-legacy),

the old URLs are marked as "legacy".

So far the only change I can tell is a nicer authentication UI.