### PR TITLE
Remove unecessary option fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,10 @@ provider :linkedin, ENV['LINKEDIN_KEY'], ENV['LINKEDIN_SECRET'], :fields => ['id
 
 To see a complete list of available fields, consult the LinkedIn documentation at: https://developer.linkedin.com/documents/profile-fields
 
-## Other Options
-
-* `secure_image_url` - Set to `true` to use https for the profile picture url. Default is `false`.
-
 ## Contributing
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+1.  Fork it
+2.  Create your feature branch (`git checkout -b my-new-feature`)
+3.  Commit your changes (`git commit -am 'Add some feature'`)
+4.  Push to the branch (`git push origin my-new-feature`)
+5.  Create new Pull Request

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -60,16 +60,10 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get("/v1/people/~:(#{option_fields.join(',')})?format=json").parsed
+        @raw_info ||= access_token.get("/v1/people/~:(#{fields.join(',')})?format=json").parsed
       end
 
       private
-
-      def option_fields
-        fields = options.fields
-        fields.map! { |f| f == "picture-url" ? "picture-url;secure=true" : f } if !!options[:secure_image_url]
-        fields
-      end
 
       def user_name
         name = "#{raw_info['firstName']} #{raw_info['lastName']}".strip

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -79,7 +79,6 @@ describe OmniAuth::Strategies::LinkedIn do
       response = double('response', :parsed => { :foo => 'bar' })
       expect(access_token).to receive(:get).with("/v1/people/~:(baz,qux)?format=json").and_return(response)
 
-      allow(subject).to receive(:option_fields) { ['baz', 'qux'] }
       allow(subject).to receive(:access_token) { access_token }
     end
 
@@ -97,25 +96,6 @@ describe OmniAuth::Strategies::LinkedIn do
       it 'sets default scope' do
         expect(subject.authorize_params['scope']).to eq('r_basicprofile r_emailaddress')
       end
-    end
-  end
-
-  describe '#option_fields' do
-    it 'returns options fields' do
-      subject.stub(:options => double('options', :fields => ['foo', 'bar']).as_null_object)
-      expect(subject.send(:option_fields)).to eq(['foo', 'bar'])
-    end
-
-    it 'http avatar image by default' do
-      subject.stub(:options => double('options', :fields => ['picture-url']))
-      allow(subject.options).to receive(:[]).with(:secure_image_url).and_return(false)
-      expect(subject.send(:option_fields)).to eq(['picture-url'])
-    end
-
-    it 'https avatar image if secure_image_url truthy' do
-      subject.stub(:options => double('options', :fields => ['picture-url']))
-      allow(subject.options).to receive(:[]).with(:secure_image_url).and_return(true)
-      expect(subject.send(:option_fields)).to eq(['picture-url;secure=true'])
     end
   end
 end


### PR DESCRIPTION
Last changes on LinkedIn break your code if the setup uses `secure_image_url: true` that anyway it is not necessary as LinkedIn always sends back the `pictureUrl` attribute as **https**. This PR intents to simplify LinkedIn oauth strategy by getting rid of that unique option field.