### PR TITLE
Add refresh_token support

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -42,7 +42,8 @@ module OmniAuth
       def access_token
         ::OAuth2::AccessToken.new(client, oauth2_access_token.token, {
           :expires_in => oauth2_access_token.expires_in,
-          :expires_at => oauth2_access_token.expires_at
+          :expires_at => oauth2_access_token.expires_at,
+          :refresh_token => oauth2_access_token.refresh_token
         })
       end
 

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -85,9 +85,10 @@ describe OmniAuth::Strategies::LinkedIn do
     let(:expires_in) { 3600 }
     let(:expires_at) { 946688400 }
     let(:token) { 'token' }
+    let(:refresh_token) { 'refresh_token' }
     let(:access_token) do
       instance_double OAuth2::AccessToken, :expires_in => expires_in,
-        :expires_at => expires_at, :token => token
+        :expires_at => expires_at, :token => token, :refresh_token => refresh_token
     end
 
     before :each do


### PR DESCRIPTION
LinkedIn support programmatic refresh: https://docs.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens

This PR adds support for making the refresh token available in the OmniAuth response.