### PR TITLE
Add basic profile v2 support

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -6,22 +6,13 @@ module OmniAuth
       option :name, 'linkedin'
 
       option :client_options, {
-        site: 'https://api.linkedin.com',
-        authorize_url: 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        token_url: 'https://www.linkedin.com/oauth/v2/accessToken'
+        :site => 'https://api.linkedin.com',
+        :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
+        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
       }
 
-      option :scope, 'r_basicprofile r_emailaddress'
-      option :fields, %w[
-        id
-        first-name
-        last-name
-        picture-url
-        email-address
-        vanity-name
-        maiden-name
-        headline
-      ]
+      option :scope, 'r_liteprofile r_emailaddress'
+      option :fields, ['id', 'first-name', 'last-name', 'picture-url', 'email-address']
 
       uid do
         raw_info['id']
@@ -29,13 +20,10 @@ module OmniAuth
 
       info do
         {
-          email: email_address,
-          first_name: localized_field('firstName'),
-          last_name: localized_field('lastName'),
-          vanity_name: raw_info['vanityName'],
-          maiden_name: localized_field('maidenName'),
-          headline: localized_field('headline'),
-          picture_url: picture_url
+          :email => email_address,
+          :first_name => localized_field('firstName'),
+          :last_name => localized_field('lastName'),
+          :picture_url => picture_url
         }
       end
 
@@ -93,10 +81,7 @@ module OmniAuth
           'id' => 'id',
           'first-name' => 'firstName',
           'last-name' => 'lastName',
-          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
-          'vanity-name' => 'vanityName',
-          'maiden-name' => 'maidenName',
-          'headline' => 'headline'
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)'
         }
       end
 

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -6,13 +6,22 @@ module OmniAuth
       option :name, 'linkedin'
 
       option :client_options, {
-        :site => 'https://api.linkedin.com',
-        :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
+        site: 'https://api.linkedin.com',
+        authorize_url: 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
+        token_url: 'https://www.linkedin.com/oauth/v2/accessToken'
       }
 
-      option :scope, 'r_liteprofile r_emailaddress'
-      option :fields, ['id', 'first-name', 'last-name', 'picture-url', 'email-address']
+      option :scope, 'r_basicprofile r_emailaddress'
+      option :fields, %w[
+        id
+        first-name
+        last-name
+        picture-url
+        email-address
+        vanity-name
+        maiden-name
+        headline
+      ]
 
       uid do
         raw_info['id']
@@ -20,10 +29,14 @@ module OmniAuth
 
       info do
         {
-          :email => email_address,
-          :first_name => localized_field('firstName'),
-          :last_name => localized_field('lastName'),
-          :picture_url => picture_url
+          email: email_address,
+          first_name: localized_field('firstName'),
+          last_name: localized_field('lastName'),
+          vanity_name: raw_info['vanityName'],
+          maiden_name: localized_field('maidenName'),
+          headline: localized_field('headline'),
+          picture_url: picture_url,
+          profile_url: profile_url
         }
       end
 
@@ -81,7 +94,10 @@ module OmniAuth
           'id' => 'id',
           'first-name' => 'firstName',
           'last-name' => 'lastName',
-          'picture-url' => 'profilePicture(displayImage~:playableStreams)'
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
+          'vanity-name' => 'vanityName',
+          'maiden-name' => 'maidenName',
+          'headline' => 'headline'
         }
       end
 
@@ -110,6 +126,12 @@ module OmniAuth
         return unless picture_available?
 
         picture_references.last['identifiers'].first['identifier']
+      end
+
+      def profile_url
+        return nil if raw_info['vanityName'].nil?
+
+        "www.linkedin.com/in/{raw_info['vanityName']}"
       end
 
       def picture_available?

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -131,7 +131,7 @@ module OmniAuth
       def profile_url
         return nil if raw_info['vanityName'].nil?
 
-        "www.linkedin.com/in/{raw_info['vanityName']}"
+        "www.linkedin.com/in/#{raw_info['vanityName']}"
       end
 
       def picture_available?

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -6,13 +6,22 @@ module OmniAuth
       option :name, 'linkedin'
 
       option :client_options, {
-        :site => 'https://api.linkedin.com',
-        :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
+        site: 'https://api.linkedin.com',
+        authorize_url: 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
+        token_url: 'https://www.linkedin.com/oauth/v2/accessToken'
       }
 
-      option :scope, 'r_liteprofile r_emailaddress'
-      option :fields, ['id', 'first-name', 'last-name', 'picture-url', 'email-address']
+      option :scope, 'r_basicprofile r_emailaddress'
+      option :fields, %w[
+        id
+        first-name
+        last-name
+        picture-url
+        email-address
+        vanity-name
+        maiden-name
+        headline
+      ]
 
       uid do
         raw_info['id']
@@ -20,10 +29,13 @@ module OmniAuth
 
       info do
         {
-          :email => email_address,
-          :first_name => localized_field('firstName'),
-          :last_name => localized_field('lastName'),
-          :picture_url => picture_url
+          email: email_address,
+          first_name: localized_field('firstName'),
+          last_name: localized_field('lastName'),
+          vanity_name: raw_info['vanityName'],
+          maiden_name: localized_field('maidenName'),
+          headline: localized_field('headline'),
+          picture_url: picture_url
         }
       end
 
@@ -81,7 +93,10 @@ module OmniAuth
           'id' => 'id',
           'first-name' => 'firstName',
           'last-name' => 'lastName',
-          'picture-url' => 'profilePicture(displayImage~:playableStreams)'
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
+          'vanity-name' => 'vanityName',
+          'maiden-name' => 'maidenName',
+          'headline' => 'headline'
         }
       end
 

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -35,8 +35,7 @@ module OmniAuth
           vanity_name: raw_info['vanityName'],
           maiden_name: localized_field('maidenName'),
           headline: localized_field('headline'),
-          picture_url: picture_url,
-          profile_url: profile_url
+          picture_url: picture_url
         }
       end
 
@@ -126,12 +125,6 @@ module OmniAuth
         return unless picture_available?
 
         picture_references.last['identifiers'].first['identifier']
-      end
-
-      def profile_url
-        return nil if raw_info['vanityName'].nil?
-
-        "www.linkedin.com/in/#{raw_info['vanityName']}"
       end
 
       def picture_available?

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -1,0 +1,46 @@
+require 'omniauth-oauth2'
+
+module OmniAuth
+  module Strategies
+    class LinkedInBasic < LinkedIn
+      option :scope, 'r_basicprofile r_emailaddress'
+
+      option :fields, %w[
+        id
+        first-name
+        last-name
+        picture-url
+        email-address
+        vanity-name
+        maiden-name
+        headline
+      ]
+
+      info do
+        {
+          email: email_address,
+          first_name: localized_field('firstName'),
+          last_name: localized_field('lastName'),
+          vanity_name: raw_info['vanityName'],
+          maiden_name: localized_field('maidenName'),
+          headline: localized_field('headline'),
+          picture_url: picture_url
+        }
+      end
+
+      private
+
+      def fields_mapping
+        {
+          'id' => 'id',
+          'first-name' => 'firstName',
+          'last-name' => 'lastName',
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
+          'vanity-name' => 'vanityName',
+          'maiden-name' => 'maidenName',
+          'headline' => 'headline'
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updated the forked branch to include new fields available to us with the new basic profile rights from LinkedIn.

More info on basic profile fields:
https://docs.microsoft.com/en-us/linkedin/shared/references/v2/profile/basic-profile?context=linkedin/consumer/context