### PR TITLE
Add basic profile support

### DIFF
--- a/lib/omniauth-linkedin-oauth2.rb
+++ b/lib/omniauth-linkedin-oauth2.rb
@@ -1,2 +1,3 @@
 require "omniauth-linkedin-oauth2/version"
 require "omniauth/strategies/linkedin"
+require "omniauth/strategies/linkedin_basic"

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -6,22 +6,13 @@ module OmniAuth
       option :name, 'linkedin'
 
       option :client_options, {
-        site: 'https://api.linkedin.com',
-        authorize_url: 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        token_url: 'https://www.linkedin.com/oauth/v2/accessToken'
+        :site => 'https://api.linkedin.com',
+        :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
+        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
       }
 
-      option :scope, 'r_basicprofile r_emailaddress'
-      option :fields, %w[
-        id
-        first-name
-        last-name
-        picture-url
-        email-address
-        vanity-name
-        maiden-name
-        headline
-      ]
+      option :scope, 'r_liteprofile r_emailaddress'
+      option :fields, ['id', 'first-name', 'last-name', 'picture-url', 'email-address']
 
       uid do
         raw_info['id']
@@ -29,13 +20,10 @@ module OmniAuth
 
       info do
         {
-          email: email_address,
-          first_name: localized_field('firstName'),
-          last_name: localized_field('lastName'),
-          vanity_name: raw_info['vanityName'],
-          maiden_name: localized_field('maidenName'),
-          headline: localized_field('headline'),
-          picture_url: picture_url
+          :email => email_address,
+          :first_name => localized_field('firstName'),
+          :last_name => localized_field('lastName'),
+          :picture_url => picture_url
         }
       end
 
@@ -93,10 +81,7 @@ module OmniAuth
           'id' => 'id',
           'first-name' => 'firstName',
           'last-name' => 'lastName',
-          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
-          'vanity-name' => 'vanityName',
-          'maiden-name' => 'maidenName',
-          'headline' => 'headline'
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)'
         }
       end
 

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -6,13 +6,22 @@ module OmniAuth
       option :name, 'linkedin'
 
       option :client_options, {
-        :site => 'https://api.linkedin.com',
-        :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
+        site: 'https://api.linkedin.com',
+        authorize_url: 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
+        token_url: 'https://www.linkedin.com/oauth/v2/accessToken'
       }
 
-      option :scope, 'r_liteprofile r_emailaddress'
-      option :fields, ['id', 'first-name', 'last-name', 'picture-url', 'email-address']
+      option :scope, 'r_basicprofile r_emailaddress'
+      option :fields, %w[
+        id
+        first-name
+        last-name
+        picture-url
+        email-address
+        vanity-name
+        maiden-name
+        headline
+      ]
 
       uid do
         raw_info['id']
@@ -20,10 +29,14 @@ module OmniAuth
 
       info do
         {
-          :email => email_address,
-          :first_name => localized_field('firstName'),
-          :last_name => localized_field('lastName'),
-          :picture_url => picture_url
+          email: email_address,
+          first_name: localized_field('firstName'),
+          last_name: localized_field('lastName'),
+          vanity_name: raw_info['vanityName'],
+          maiden_name: localized_field('maidenName'),
+          headline: localized_field('headline'),
+          picture_url: picture_url,
+          profile_url: profile_url
         }
       end
 
@@ -81,7 +94,10 @@ module OmniAuth
           'id' => 'id',
           'first-name' => 'firstName',
           'last-name' => 'lastName',
-          'picture-url' => 'profilePicture(displayImage~:playableStreams)'
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
+          'vanity-name' => 'vanityName',
+          'maiden-name' => 'maidenName',
+          'headline' => 'headline'
         }
       end
 
@@ -110,6 +126,12 @@ module OmniAuth
         return unless picture_available?
 
         picture_references.last['identifiers'].first['identifier']
+      end
+
+      def profile_url
+        return nil if raw_info['vanityName'].nil?
+
+        "www.linkedin.com/in/{raw_info['vanityName']}"
       end
 
       def picture_available?

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -131,7 +131,7 @@ module OmniAuth
       def profile_url
         return nil if raw_info['vanityName'].nil?
 
-        "www.linkedin.com/in/{raw_info['vanityName']}"
+        "www.linkedin.com/in/#{raw_info['vanityName']}"
       end
 
       def picture_available?

--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -35,8 +35,7 @@ module OmniAuth
           vanity_name: raw_info['vanityName'],
           maiden_name: localized_field('maidenName'),
           headline: localized_field('headline'),
-          picture_url: picture_url,
-          profile_url: profile_url
+          picture_url: picture_url
         }
       end
 
@@ -126,12 +125,6 @@ module OmniAuth
         return unless picture_available?
 
         picture_references.last['identifiers'].first['identifier']
-      end
-
-      def profile_url
-        return nil if raw_info['vanityName'].nil?
-
-        "www.linkedin.com/in/#{raw_info['vanityName']}"
       end
 
       def picture_available?

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -3,7 +3,7 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class LinkedInBasic < LinkedIn
-      option :name, 'linkedin_basic'
+      option :name, 'linkedin'
 
       option :scope, 'r_basicprofile r_emailaddress'
 

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -18,13 +18,13 @@ module OmniAuth
 
       info do
         {
-          email: email_address,
-          first_name: localized_field('firstName'),
-          last_name: localized_field('lastName'),
-          vanity_name: raw_info['vanityName'],
-          maiden_name: localized_field('maidenName'),
-          headline: localized_field('headline'),
-          picture_url: picture_url
+          :email => email_address,
+          :first_name => localized_field('firstName'),
+          :last_name => localized_field('lastName'),
+          :vanity_name => raw_info['vanityName'],
+          :maiden_name => localized_field('maidenName'),
+          :headline => localized_field('headline'),
+          :picture_url => picture_url
         }
       end
 

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -46,3 +46,5 @@ module OmniAuth
     end
   end
 end
+
+OmniAuth.config.add_camelization 'linkedin_basic', 'LinkedInBasic'

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -1,0 +1,46 @@
+require 'omniauth-oauth2'
+
+module OmniAuth
+  module Strategies
+    class LinkedInBasic < LinkedIn
+      option :scope, 'r_basicprofile r_emailaddress'
+
+      option :fields, %w[
+        id
+        first-name
+        last-name
+        picture-url
+        email-address
+        vanity-name
+        maiden-name
+        headline
+      ]
+
+      info do
+        {
+          email: email_address,
+          first_name: localized_field('firstName'),
+          last_name: localized_field('lastName'),
+          vanity_name: raw_info['vanityName'],
+          maiden_name: localized_field('maidenName'),
+          headline: localized_field('headline'),
+          picture_url: picture_url
+        }
+      end
+
+      private
+
+      def fields_mapping
+        {
+          'id' => 'id',
+          'first-name' => 'firstName',
+          'last-name' => 'lastName',
+          'picture-url' => 'profilePicture(displayImage~:playableStreams)',
+          'vanity-name' => 'vanityName',
+          'maiden-name' => 'maidenName',
+          'headline' => 'headline'
+        }
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -3,7 +3,7 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class LinkedInBasic < LinkedIn
-      option :name, 'linkedinbasic'
+      option :name, 'linkedin_basic'
 
       option :scope, 'r_basicprofile r_emailaddress'
 

--- a/lib/omniauth/strategies/linkedin_basic.rb
+++ b/lib/omniauth/strategies/linkedin_basic.rb
@@ -3,6 +3,8 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class LinkedInBasic < LinkedIn
+      option :name, 'linkedinbasic'
+
       option :scope, 'r_basicprofile r_emailaddress'
 
       option :fields, %w[

--- a/spec/omniauth/strategies/linkedin_basic_spec.rb
+++ b/spec/omniauth/strategies/linkedin_basic_spec.rb
@@ -43,7 +43,7 @@ describe OmniAuth::Strategies::LinkedInBasic do
 
     let(:parsed_response) { Hash[:foo => 'bar'] }
 
-    let(:profile_endpoint) { "/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams),vanityName,maidenName,headline)" }
+    let(:profile_endpoint) { '/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams),vanityName,maidenName,headline)' }
     let(:email_address_endpoint) { '/v2/emailAddress?q=members&projection=(elements*(handle~))' }
 
     let(:email_address_response) { instance_double OAuth2::Response, parsed: parsed_response }

--- a/spec/omniauth/strategies/linkedin_basic_spec.rb
+++ b/spec/omniauth/strategies/linkedin_basic_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+require 'omniauth-linkedin-oauth2'
+
+describe OmniAuth::Strategies::LinkedInBasic do
+  subject { OmniAuth::Strategies::LinkedInBasic.new(nil) }
+
+  it 'adds camelization for itself' do
+    expect(OmniAuth::Utils.camelize('linkedin_basic')).to eq('LinkedInBasic')
+  end
+
+  describe '#client' do
+    it 'has correct LinkedIn site' do
+      expect(subject.client.site).to eq('https://api.linkedin.com')
+    end
+
+    it 'has correct `authorize_url`' do
+      expect(subject.client.options[:authorize_url]).to eq('https://www.linkedin.com/oauth/v2/authorization?response_type=code')
+    end
+
+    it 'has correct `token_url`' do
+      expect(subject.client.options[:token_url]).to eq('https://www.linkedin.com/oauth/v2/accessToken')
+    end
+  end
+
+  describe '#callback_path' do
+    it 'has the correct callback path' do
+      expect(subject.callback_path).to eq('/auth/linkedin_basic/callback')
+    end
+  end
+
+  describe '#uid' do
+    before :each do
+      allow(subject).to receive(:raw_info) { Hash['id' => 'uid'] }
+    end
+
+    it 'returns the id from raw_info' do
+      expect(subject.uid).to eq('uid')
+    end
+  end
+
+  describe '#info / #raw_info' do
+    let(:access_token) { instance_double OAuth2::AccessToken }
+
+    let(:parsed_response) { Hash[:foo => 'bar'] }
+
+    let(:profile_endpoint) { "/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams),vanityName,maidenName,headline)" }
+    let(:email_address_endpoint) { '/v2/emailAddress?q=members&projection=(elements*(handle~))' }
+
+    let(:email_address_response) { instance_double OAuth2::Response, parsed: parsed_response }
+    let(:profile_response) { instance_double OAuth2::Response, parsed: parsed_response }
+
+    before :each do
+      allow(subject).to receive(:access_token).and_return access_token
+
+      allow(access_token).to receive(:get)
+        .with(email_address_endpoint)
+        .and_return(email_address_response)
+
+      allow(access_token).to receive(:get)
+        .with(profile_endpoint)
+        .and_return(profile_response)
+    end
+
+    it 'returns parsed responses using access token' do
+      expect(subject.info).to have_key :email
+      expect(subject.info).to have_key :first_name
+      expect(subject.info).to have_key :last_name
+      expect(subject.info).to have_key :picture_url
+
+      expect(subject.raw_info).to eq({ :foo => 'bar' })
+    end
+  end
+
+  describe '#extra' do
+    let(:raw_info) { Hash[:foo => 'bar'] }
+
+    before :each do
+      allow(subject).to receive(:raw_info).and_return raw_info
+    end
+
+    specify { expect(subject.extra['raw_info']).to eq raw_info }
+  end
+
+  describe '#access_token' do
+    let(:expires_in) { 3600 }
+    let(:expires_at) { 946688400 }
+    let(:token) { 'token' }
+    let(:access_token) do
+      instance_double OAuth2::AccessToken, :expires_in => expires_in,
+        :expires_at => expires_at, :token => token
+    end
+
+    before :each do
+      allow(subject).to receive(:oauth2_access_token).and_return access_token
+    end
+
+    specify { expect(subject.access_token.expires_in).to eq expires_in }
+    specify { expect(subject.access_token.expires_at).to eq expires_at }
+  end
+
+  describe '#authorize_params' do
+    describe 'scope' do
+      before :each do
+        allow(subject).to receive(:session).and_return({})
+      end
+
+      it 'sets default scope' do
+        expect(subject.authorize_params['scope']).to eq('r_basicprofile r_emailaddress')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created a `r_basicprofile` version of the LinkedIn class as a subclass.

This allows for previous versions to work alongside the new `r_basicprofile` permissions for those who have it