### PR TITLE
Update to version 1.0.1

### DIFF
--- a/lib/omniauth-linkedin-oauth2/version.rb
+++ b/lib/omniauth-linkedin-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LinkedInOAuth2
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
There is an important issue that was fixed here https://github.com/decioferreira/omniauth-linkedin-oauth2/pull/71, however it's not possible to update via bundle, unless we do a monkey-patch, or create a new fork.

I think upgrading this gem version to v1.0.1 will help more people as well.