### PR TITLE
Updates to support current version of LinkedIn APIs

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -93,12 +93,22 @@ module OmniAuth
       end
 
       def localized_field field_name
-        raw_info.dig(*[field_name, 'localized', field_locale(field_name)])
+        value = raw_info[field_name]
+        if value.is_a?(Hash)
+          value.dig('localized', field_locale(field_name))
+        else
+          value
+        end
       end
 
       def field_locale field_name
-        "#{ raw_info[field_name]['preferredLocale']['language'] }_" \
-          "#{ raw_info[field_name]['preferredLocale']['country'] }"
+        field_value = raw_info[field_name]
+        return unless field_value.is_a?(Hash)
+
+        preferred_locale = field_value['preferredLocale']
+        return unless preferred_locale
+
+        "#{preferred_locale['language'] }_#{preferred_locale['country'] }"
       end
 
       def picture_url

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -30,7 +30,7 @@ describe OmniAuth::Strategies::LinkedIn do
 
   describe '#uid' do
     before :each do
-      allow(subject).to receive(:raw_info) { Hash['id' => 'uid'] }
+      allow(subject).to receive(:raw_info) { Hash['sub' => 'uid'] }
     end
 
     it 'returns the id from raw_info' do
@@ -43,18 +43,12 @@ describe OmniAuth::Strategies::LinkedIn do
 
     let(:parsed_response) { Hash[:foo => 'bar'] }
 
-    let(:profile_endpoint) { '/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))' }
-    let(:email_address_endpoint) { '/v2/emailAddress?q=members&projection=(elements*(handle~))' }
+    let(:profile_endpoint) { '/v2/userinfo' }
 
-    let(:email_address_response) { instance_double OAuth2::Response, parsed: parsed_response }
     let(:profile_response) { instance_double OAuth2::Response, parsed: parsed_response }
 
     before :each do
       allow(subject).to receive(:access_token).and_return access_token
-
-      allow(access_token).to receive(:get)
-        .with(email_address_endpoint)
-        .and_return(email_address_response)
 
       allow(access_token).to receive(:get)
         .with(profile_endpoint)
@@ -108,7 +102,7 @@ describe OmniAuth::Strategies::LinkedIn do
       end
 
       it 'sets default scope' do
-        expect(subject.authorize_params['scope']).to eq('r_liteprofile r_emailaddress')
+        expect(subject.authorize_params['scope']).to eq('profile email w_member_social openid')
       end
     end
   end


### PR DESCRIPTION
It seems that a number of things have changed since this gem was last updated. In particular, it appears that the `r_liteprofile` and `r_emailaddress` scopes have been deprecated in favor of the `profile`, `email`, and `openid` scopes. In addition, in at least some cases (perhaps with US-based users?) the values of the various fields are returned without localization information; this PR automatically handles both the localized and non-localized cases.

Thanks to @ariclinis for his initial work on which this was based.